### PR TITLE
Update View Product Details popup to match frontend

### DIFF
--- a/client/components/DynamicIndex.tsx
+++ b/client/components/DynamicIndex.tsx
@@ -138,7 +138,6 @@ export default function DynamicIndex() {
     setShowViewDetailsPopup(true);
   };
 
-
   const scrollToProduct = () => {
     document
       .getElementById("product-section")
@@ -311,7 +310,6 @@ export default function DynamicIndex() {
                 >
                   {adminData.hero.secondaryButtonText}
                 </Button>
-
               </div>
 
               {/* Right Column - Product Image */}
@@ -926,13 +924,15 @@ export default function DynamicIndex() {
           </DialogPortal>
         </Dialog>
 
-
         {/* Sticky CTA for Mobile */}
         <StickyCTA onClick={handleCardClick} />
 
         {/* View Product Details Popup - Identical to Modal */}
         {showViewDetailsPopup && (
-          <Dialog open={showViewDetailsPopup} onOpenChange={setShowViewDetailsPopup}>
+          <Dialog
+            open={showViewDetailsPopup}
+            onOpenChange={setShowViewDetailsPopup}
+          >
             <DialogPortal>
               <DialogOverlay />
               <DialogPrimitive.Content className="fixed inset-4 z-[1001] mx-auto my-auto w-auto h-auto max-w-[calc(100vw-2rem)] max-h-[calc(100vh-2rem)] sm:inset-auto sm:left-1/2 sm:top-1/2 sm:w-full sm:max-w-[640px] sm:h-[90vh] sm:max-h-[800px] sm:translate-x-[-50%] sm:translate-y-[-50%] bg-white border-0 rounded-2xl sm:rounded-2xl shadow-2xl p-0 overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 duration-200">
@@ -948,7 +948,9 @@ export default function DynamicIndex() {
                   className="h-full flex flex-col"
                 >
                   {(() => {
-                    const popup = adminData.popups.find((p) => p.type === "view-product-details");
+                    const popup = adminData.popups.find(
+                      (p) => p.type === "view-product-details",
+                    );
                     if (!popup) return null;
 
                     return (
@@ -957,7 +959,9 @@ export default function DynamicIndex() {
                         <div className="relative flex-shrink-0 bg-white border-b border-gray-200 p-3 sm:p-6">
                           <DialogHeader>
                             <DialogTitle className="text-lg sm:text-2xl font-bold text-gray-900 leading-tight pr-10 sm:pr-12">
-                              {popup.useHeroTitle ? adminData.hero.title : popup.title}
+                              {popup.useHeroTitle
+                                ? adminData.hero.title
+                                : popup.title}
                             </DialogTitle>
                             <DialogDescription className="text-sm sm:text-sm text-gray-600 mt-2 pr-8 sm:pr-0">
                               {popup.description}
@@ -986,10 +990,20 @@ export default function DynamicIndex() {
                           {popup.showImages && (
                             <div className="relative mb-4 sm:mb-6">
                               <div className="relative overflow-hidden rounded-xl shadow-lg bg-gray-50 mx-auto max-w-[280px] sm:max-w-none">
-                                {adminData.hero.productImages[currentImageIndex] && (
+                                {adminData.hero.productImages[
+                                  currentImageIndex
+                                ] && (
                                   <img
-                                    src={adminData.hero.productImages[currentImageIndex]}
-                                    alt={popup.useHeroTitle ? adminData.hero.title : popup.title}
+                                    src={
+                                      adminData.hero.productImages[
+                                        currentImageIndex
+                                      ]
+                                    }
+                                    alt={
+                                      popup.useHeroTitle
+                                        ? adminData.hero.title
+                                        : popup.title
+                                    }
                                     className="w-full h-40 sm:h-64 object-contain"
                                     loading="lazy"
                                   />
@@ -1028,7 +1042,8 @@ export default function DynamicIndex() {
                                 ))}
                               </div>
                               <span className="ml-2 text-sm sm:text-sm text-gray-700 font-medium">
-                                {adminData.hero.rating} ⭐ ({adminData.hero.reviewCount} reviews)
+                                {adminData.hero.rating} ⭐ (
+                                {adminData.hero.reviewCount} reviews)
                               </span>
                             </div>
                           )}
@@ -1074,25 +1089,30 @@ export default function DynamicIndex() {
                           )}
 
                           {/* More Details Section */}
-                          {popup.showMoreDetails && popup.moreDetails && popup.moreDetails.length > 0 && (
-                            <div className="mb-4 sm:mb-6">
-                              <h3 className="text-lg font-bold text-gray-900 mb-3 text-center sm:text-left">
-                                {popup.moreDetailsTitle || "More Details"}
-                              </h3>
-                              <div className="space-y-2">
-                                {popup.moreDetails.map((detail, index) => (
-                                  <div key={index} className="flex items-start gap-2 sm:gap-3">
-                                    <div className="bg-green-100 rounded-full p-1 mt-0.5 flex-shrink-0">
-                                      <Check className="h-3 w-3 text-green-600" />
+                          {popup.showMoreDetails &&
+                            popup.moreDetails &&
+                            popup.moreDetails.length > 0 && (
+                              <div className="mb-4 sm:mb-6">
+                                <h3 className="text-lg font-bold text-gray-900 mb-3 text-center sm:text-left">
+                                  {popup.moreDetailsTitle || "More Details"}
+                                </h3>
+                                <div className="space-y-2">
+                                  {popup.moreDetails.map((detail, index) => (
+                                    <div
+                                      key={index}
+                                      className="flex items-start gap-2 sm:gap-3"
+                                    >
+                                      <div className="bg-green-100 rounded-full p-1 mt-0.5 flex-shrink-0">
+                                        <Check className="h-3 w-3 text-green-600" />
+                                      </div>
+                                      <p className="text-gray-700 leading-relaxed text-sm">
+                                        {detail}
+                                      </p>
                                     </div>
-                                    <p className="text-gray-700 leading-relaxed text-sm">
-                                      {detail}
-                                    </p>
-                                  </div>
-                                ))}
+                                  ))}
+                                </div>
                               </div>
-                            </div>
-                          )}
+                            )}
                         </div>
 
                         {/* FOOTER - Fixed at bottom */}
@@ -1100,7 +1120,8 @@ export default function DynamicIndex() {
                           <div className="space-y-2 sm:space-y-3">
                             <Button
                               onClick={() => {
-                                const link = popup.primaryButtonLink || popup.buttonLink;
+                                const link =
+                                  popup.primaryButtonLink || popup.buttonLink;
                                 if (link) {
                                   window.open(link, "_blank");
                                 }

--- a/client/components/DynamicIndex.tsx
+++ b/client/components/DynamicIndex.tsx
@@ -133,6 +133,11 @@ export default function DynamicIndex() {
     setIsModalOpen(true);
   };
 
+  const handleViewDetailsClick = () => {
+    console.log("View details clicked - opening popup");
+    setShowViewDetailsPopup(true);
+  };
+
 
   const scrollToProduct = () => {
     document

--- a/client/components/DynamicIndex.tsx
+++ b/client/components/DynamicIndex.tsx
@@ -67,7 +67,6 @@ export default function DynamicIndex() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
   const [showExitIntent, setShowExitIntent] = useState(false);
-  const [showButtonPopup, setShowButtonPopup] = useState(false);
 
   const walmartUrl =
     "https://www.walmart.com/ip/Healthy-Snack-Box-Tasty-Nutrient-Rich-Variety-42-Count-by-Gift-A-Snack/14479818419?selectedSellerId=16964&selectedOfferId=BEA9DA42A8853A4C927EECB4D702F303&clickid=3PE2sMyDBxycW1s0QQThKWW7Ukp2AmR-AQ%3AGxo0&irgwc=1&sourceid=imp_3PE2sMyDBxycW1s0QQThKWW7Ukp2AmR-AQ%3AGxo0&veh=aff&wmlspartner=imp_5610446&affiliates_ad_id=565706&campaign_id=9383&sharedid=mp_16964_2016489964_knpf1_4mtlu49_BEA9DA42A8853A4C927EECB4D702F303&utm_source=landing&utm_medium=cta&utm_campaign=snackbox";
@@ -133,9 +132,6 @@ export default function DynamicIndex() {
     setIsModalOpen(true);
   };
 
-  const handleSpecialOfferClick = () => {
-    setShowButtonPopup(true);
-  };
 
   const scrollToProduct = () => {
     document
@@ -310,15 +306,6 @@ export default function DynamicIndex() {
                   {adminData.hero.secondaryButtonText}
                 </Button>
 
-                {/* Special Offer Button */}
-                <Button
-                  onClick={handleSpecialOfferClick}
-                  variant="ghost"
-                  size="sm"
-                  className="w-full mt-2 text-sm text-blue-600 hover:text-blue-700"
-                >
-                  {adminData.hero.specialOfferButtonText}
-                </Button>
               </div>
 
               {/* Right Column - Product Image */}
@@ -933,64 +920,6 @@ export default function DynamicIndex() {
           </DialogPortal>
         </Dialog>
 
-        {/* Button Triggered Popup */}
-        {showButtonPopup && (
-          <Dialog open={showButtonPopup} onOpenChange={setShowButtonPopup}>
-            <DialogPortal>
-              <DialogOverlay />
-              <DialogContent className="max-w-md">
-                <DialogHeader>
-                  <DialogTitle>
-                    {
-                      adminData.popups.find(
-                        (p) => p.type === "button-triggered",
-                      )?.title
-                    }
-                  </DialogTitle>
-                  <DialogDescription>
-                    {
-                      adminData.popups.find(
-                        (p) => p.type === "button-triggered",
-                      )?.description
-                    }
-                  </DialogDescription>
-                </DialogHeader>
-                <div className="space-y-4">
-                  {adminData.popups.find((p) => p.type === "button-triggered")
-                    ?.image && (
-                    <img
-                      src={
-                        adminData.popups.find(
-                          (p) => p.type === "button-triggered",
-                        )?.image
-                      }
-                      alt="Special Offer"
-                      className="w-full h-32 object-cover rounded-lg"
-                    />
-                  )}
-                  <Button
-                    onClick={() => {
-                      const popup = adminData.popups.find(
-                        (p) => p.type === "button-triggered",
-                      );
-                      if (popup?.buttonLink) {
-                        window.open(popup.buttonLink, "_blank");
-                      }
-                      setShowButtonPopup(false);
-                    }}
-                    className="w-full"
-                  >
-                    {
-                      adminData.popups.find(
-                        (p) => p.type === "button-triggered",
-                      )?.buttonText
-                    }
-                  </Button>
-                </div>
-              </DialogContent>
-            </DialogPortal>
-          </Dialog>
-        )}
 
         {/* Sticky CTA for Mobile */}
         <StickyCTA onClick={handleCardClick} />

--- a/client/components/DynamicIndex.tsx
+++ b/client/components/DynamicIndex.tsx
@@ -930,61 +930,206 @@ export default function DynamicIndex() {
         {/* Sticky CTA for Mobile */}
         <StickyCTA onClick={handleCardClick} />
 
-        {/* View Product Details Popup */}
+        {/* View Product Details Popup - Identical to Modal */}
         {showViewDetailsPopup && (
           <Dialog open={showViewDetailsPopup} onOpenChange={setShowViewDetailsPopup}>
             <DialogPortal>
               <DialogOverlay />
-              <DialogContent className="max-w-md">
-                <DialogHeader>
-                  <DialogTitle>
-                    {
-                      adminData.popups.find(
-                        (p) => p.type === "view-product-details",
-                      )?.title
-                    }
-                  </DialogTitle>
-                  <DialogDescription>
-                    {
-                      adminData.popups.find(
-                        (p) => p.type === "view-product-details",
-                      )?.description
-                    }
-                  </DialogDescription>
-                </DialogHeader>
-                <div className="space-y-4">
-                  {adminData.popups.find((p) => p.type === "view-product-details")
-                    ?.image && (
-                    <img
-                      src={
-                        adminData.popups.find(
-                          (p) => p.type === "view-product-details",
-                        )?.image
-                      }
-                      alt="Product Details"
-                      className="w-full h-32 object-cover rounded-lg"
-                    />
-                  )}
-                  <Button
-                    onClick={() => {
-                      const popup = adminData.popups.find(
-                        (p) => p.type === "view-product-details",
-                      );
-                      if (popup?.buttonLink) {
-                        window.open(popup.buttonLink, "_blank");
-                      }
-                      setShowViewDetailsPopup(false);
-                    }}
-                    className="w-full"
-                  >
-                    {
-                      adminData.popups.find(
-                        (p) => p.type === "view-product-details",
-                      )?.buttonText
-                    }
-                  </Button>
-                </div>
-              </DialogContent>
+              <DialogPrimitive.Content className="fixed inset-4 z-[1001] mx-auto my-auto w-auto h-auto max-w-[calc(100vw-2rem)] max-h-[calc(100vh-2rem)] sm:inset-auto sm:left-1/2 sm:top-1/2 sm:w-full sm:max-w-[640px] sm:h-[90vh] sm:max-h-[800px] sm:translate-x-[-50%] sm:translate-y-[-50%] bg-white border-0 rounded-2xl sm:rounded-2xl shadow-2xl p-0 overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 duration-200">
+                <DialogPrimitive.Close className="absolute right-3 top-3 z-50 p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition-colors shadow-md sm:hidden">
+                  <X className="h-5 w-5 text-gray-600" />
+                  <span className="sr-only">Close</span>
+                </DialogPrimitive.Close>
+                <motion.div
+                  initial={{ scale: 0.95, opacity: 0 }}
+                  animate={{ scale: 1, opacity: 1 }}
+                  exit={{ scale: 0.95, opacity: 0 }}
+                  transition={{ duration: 0.2 }}
+                  className="h-full flex flex-col"
+                >
+                  {(() => {
+                    const popup = adminData.popups.find((p) => p.type === "view-product-details");
+                    if (!popup) return null;
+
+                    return (
+                      <>
+                        {/* HEADER - Fixed at top */}
+                        <div className="relative flex-shrink-0 bg-white border-b border-gray-200 p-3 sm:p-6">
+                          <DialogHeader>
+                            <DialogTitle className="text-lg sm:text-2xl font-bold text-gray-900 leading-tight pr-10 sm:pr-12">
+                              {popup.useHeroTitle ? adminData.hero.title : popup.title}
+                            </DialogTitle>
+                            <DialogDescription className="text-sm sm:text-sm text-gray-600 mt-2 pr-8 sm:pr-0">
+                              {popup.description}
+                            </DialogDescription>
+                          </DialogHeader>
+
+                          {/* Close Button - Desktop only */}
+                          <button
+                            onClick={() => setShowViewDetailsPopup(false)}
+                            className="hidden sm:block absolute top-4 right-4 p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition-colors z-10 shadow-sm"
+                            aria-label="Close popup"
+                          >
+                            <X className="h-6 w-6" />
+                          </button>
+                        </div>
+
+                        {/* BODY - Scrollable content */}
+                        <div
+                          className="flex-1 overflow-y-auto px-3 py-4 sm:p-6"
+                          style={{
+                            maxHeight: "calc(100vh - 180px - 140px)",
+                            WebkitOverflowScrolling: "touch",
+                          }}
+                        >
+                          {/* Product Images */}
+                          {popup.showImages && (
+                            <div className="relative mb-4 sm:mb-6">
+                              <div className="relative overflow-hidden rounded-xl shadow-lg bg-gray-50 mx-auto max-w-[280px] sm:max-w-none">
+                                {adminData.hero.productImages[currentImageIndex] && (
+                                  <img
+                                    src={adminData.hero.productImages[currentImageIndex]}
+                                    alt={popup.useHeroTitle ? adminData.hero.title : popup.title}
+                                    className="w-full h-40 sm:h-64 object-contain"
+                                    loading="lazy"
+                                  />
+                                )}
+                              </div>
+
+                              {adminData.hero.productImages.length > 1 && (
+                                <>
+                                  <button
+                                    onClick={prevImage}
+                                    className="absolute left-2 top-1/2 -translate-y-1/2 bg-white/90 rounded-full p-2 shadow-md hover:bg-white touch-manipulation"
+                                    aria-label="Previous image"
+                                  >
+                                    <ChevronLeft className="h-4 w-4" />
+                                  </button>
+                                  <button
+                                    onClick={nextImage}
+                                    className="absolute right-2 top-1/2 -translate-y-1/2 bg-white/90 rounded-full p-2 shadow-md hover:bg-white touch-manipulation"
+                                  >
+                                    <ChevronRight className="h-4 w-4" />
+                                  </button>
+                                </>
+                              )}
+                            </div>
+                          )}
+
+                          {/* Rating */}
+                          {popup.showRating && (
+                            <div className="flex items-center justify-center sm:justify-start mb-4">
+                              <div className="flex">
+                                {[...Array(5)].map((_, i) => (
+                                  <Star
+                                    key={i}
+                                    className={`h-4 w-4 sm:h-4 sm:w-4 ${i < Math.floor(adminData.hero.rating) ? "text-yellow-400 fill-current" : "text-gray-300"}`}
+                                  />
+                                ))}
+                              </div>
+                              <span className="ml-2 text-sm sm:text-sm text-gray-700 font-medium">
+                                {adminData.hero.rating} ⭐ ({adminData.hero.reviewCount} reviews)
+                              </span>
+                            </div>
+                          )}
+
+                          {/* Pricing Section */}
+                          {popup.showPricing && (
+                            <div className="mb-4 p-3 sm:p-4 bg-blue-50 rounded-xl border border-blue-200">
+                              <PricingDisplay
+                                salePrice={adminData.hero.salePrice}
+                                size="lg"
+                                className="mb-2"
+                              />
+                              {popup.subscribeText && (
+                                <div className="text-sm text-green-600 font-medium">
+                                  {popup.subscribeText}
+                                </div>
+                              )}
+                              {popup.walmartText && (
+                                <div className="text-sm text-blue-600 font-medium">
+                                  {popup.walmartText}
+                                </div>
+                              )}
+                            </div>
+                          )}
+
+                          {/* Pieces Count */}
+                          {popup.showPiecesCount && (
+                            <div className="mb-4 p-3 sm:p-4 bg-gray-50 rounded-xl">
+                              <div className="flex items-center justify-center sm:justify-start gap-2">
+                                <span className="font-semibold text-gray-900 text-sm sm:text-base">
+                                  {popup.piecesCountTitle || "Pieces Count:"}
+                                </span>
+                                <span className="text-lg font-bold text-blue-600">
+                                  {popup.piecesCount || 42} Items
+                                </span>
+                              </div>
+                              {popup.piecesCountSubtitle && (
+                                <p className="text-sm text-gray-600 mt-1 text-center sm:text-left">
+                                  {popup.piecesCountSubtitle}
+                                </p>
+                              )}
+                            </div>
+                          )}
+
+                          {/* More Details Section */}
+                          {popup.showMoreDetails && popup.moreDetails && popup.moreDetails.length > 0 && (
+                            <div className="mb-4 sm:mb-6">
+                              <h3 className="text-lg font-bold text-gray-900 mb-3 text-center sm:text-left">
+                                {popup.moreDetailsTitle || "More Details"}
+                              </h3>
+                              <div className="space-y-2">
+                                {popup.moreDetails.map((detail, index) => (
+                                  <div key={index} className="flex items-start gap-2 sm:gap-3">
+                                    <div className="bg-green-100 rounded-full p-1 mt-0.5 flex-shrink-0">
+                                      <Check className="h-3 w-3 text-green-600" />
+                                    </div>
+                                    <p className="text-gray-700 leading-relaxed text-sm">
+                                      {detail}
+                                    </p>
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                        </div>
+
+                        {/* FOOTER - Fixed at bottom */}
+                        <div className="flex-shrink-0 bg-white border-t border-gray-200 p-3 sm:p-6 sticky bottom-0 z-10 shadow-lg sm:shadow-none">
+                          <div className="space-y-2 sm:space-y-3">
+                            <Button
+                              onClick={() => {
+                                const link = popup.primaryButtonLink || popup.buttonLink;
+                                if (link) {
+                                  window.open(link, "_blank");
+                                }
+                                setShowViewDetailsPopup(false);
+                              }}
+                              size="lg"
+                              className="w-full bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white py-3 sm:py-4 text-base sm:text-lg font-bold rounded-xl shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-300 touch-manipulation"
+                            >
+                              {popup.primaryButtonText || popup.buttonText}
+                              <ShoppingCart className="ml-2 h-5 w-5" />
+                            </Button>
+
+                            {popup.secondaryButtonText && (
+                              <Button
+                                onClick={() => setShowViewDetailsPopup(false)}
+                                variant="outline"
+                                size="lg"
+                                className="w-full py-2 sm:py-3 text-sm sm:text-base font-semibold rounded-xl touch-manipulation border-2"
+                              >
+                                {popup.secondaryButtonText}
+                              </Button>
+                            )}
+                          </div>
+                        </div>
+                      </>
+                    );
+                  })()}
+                </motion.div>
+              </DialogPrimitive.Content>
             </DialogPortal>
           </Dialog>
         )}

--- a/client/components/DynamicIndex.tsx
+++ b/client/components/DynamicIndex.tsx
@@ -67,6 +67,7 @@ export default function DynamicIndex() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
   const [showExitIntent, setShowExitIntent] = useState(false);
+  const [showViewDetailsPopup, setShowViewDetailsPopup] = useState(false);
 
   const walmartUrl =
     "https://www.walmart.com/ip/Healthy-Snack-Box-Tasty-Nutrient-Rich-Variety-42-Count-by-Gift-A-Snack/14479818419?selectedSellerId=16964&selectedOfferId=BEA9DA42A8853A4C927EECB4D702F303&clickid=3PE2sMyDBxycW1s0QQThKWW7Ukp2AmR-AQ%3AGxo0&irgwc=1&sourceid=imp_3PE2sMyDBxycW1s0QQThKWW7Ukp2AmR-AQ%3AGxo0&veh=aff&wmlspartner=imp_5610446&affiliates_ad_id=565706&campaign_id=9383&sharedid=mp_16964_2016489964_knpf1_4mtlu49_BEA9DA42A8853A4C927EECB4D702F303&utm_source=landing&utm_medium=cta&utm_campaign=snackbox";

--- a/client/components/DynamicIndex.tsx
+++ b/client/components/DynamicIndex.tsx
@@ -295,7 +295,7 @@ export default function DynamicIndex() {
 
                 {/* Primary CTA */}
                 <Button
-                  onClick={handleCardClick}
+                  onClick={handleViewDetailsClick}
                   size="lg"
                   className="w-full bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white py-3 sm:py-4 text-lg sm:text-xl font-bold rounded-2xl shadow-2xl hover:shadow-3xl transform hover:scale-105 transition-all duration-300 mb-3 sm:mb-4 touch-manipulation"
                 >
@@ -414,7 +414,7 @@ export default function DynamicIndex() {
             {/* CTA after Benefits */}
             <div className="text-center mt-8 sm:mt-12">
               <Button
-                onClick={handleCardClick}
+                onClick={handleViewDetailsClick}
                 size="lg"
                 className="bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white px-6 sm:px-8 py-3 sm:py-4 text-base sm:text-lg font-bold rounded-2xl shadow-xl hover:shadow-2xl transform hover:scale-105 transition-all duration-300 touch-manipulation"
               >
@@ -490,7 +490,7 @@ export default function DynamicIndex() {
               {/* CTA after Trust */}
               <div className="text-center mt-8">
                 <Button
-                  onClick={handleCardClick}
+                  onClick={handleViewDetailsClick}
                   size="lg"
                   className="bg-white text-blue-600 hover:bg-gray-50 px-6 sm:px-8 py-3 sm:py-4 text-base sm:text-lg font-bold rounded-2xl shadow-xl hover:shadow-2xl transform hover:scale-105 transition-all duration-300 touch-manipulation"
                 >
@@ -540,7 +540,7 @@ export default function DynamicIndex() {
             {/* CTA after Gallery */}
             <div className="text-center mt-8 sm:mt-12">
               <Button
-                onClick={handleCardClick}
+                onClick={handleViewDetailsClick}
                 size="lg"
                 className="bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white px-6 sm:px-8 py-3 sm:py-4 text-base sm:text-lg font-bold rounded-2xl shadow-xl hover:shadow-2xl transform hover:scale-105 transition-all duration-300 touch-manipulation"
               >
@@ -655,7 +655,7 @@ export default function DynamicIndex() {
 
                 {/* Enhanced CTA Button */}
                 <Button
-                  onClick={handleCardClick}
+                  onClick={handleViewDetailsClick}
                   size="lg"
                   className="w-full bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800 text-white px-8 py-6 text-xl font-bold rounded-2xl shadow-2xl hover:shadow-3xl transform hover:scale-105 transition-all duration-300 touch-manipulation mb-6"
                 >

--- a/client/components/DynamicIndex.tsx
+++ b/client/components/DynamicIndex.tsx
@@ -930,6 +930,65 @@ export default function DynamicIndex() {
         {/* Sticky CTA for Mobile */}
         <StickyCTA onClick={handleCardClick} />
 
+        {/* View Product Details Popup */}
+        {showViewDetailsPopup && (
+          <Dialog open={showViewDetailsPopup} onOpenChange={setShowViewDetailsPopup}>
+            <DialogPortal>
+              <DialogOverlay />
+              <DialogContent className="max-w-md">
+                <DialogHeader>
+                  <DialogTitle>
+                    {
+                      adminData.popups.find(
+                        (p) => p.type === "view-product-details",
+                      )?.title
+                    }
+                  </DialogTitle>
+                  <DialogDescription>
+                    {
+                      adminData.popups.find(
+                        (p) => p.type === "view-product-details",
+                      )?.description
+                    }
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-4">
+                  {adminData.popups.find((p) => p.type === "view-product-details")
+                    ?.image && (
+                    <img
+                      src={
+                        adminData.popups.find(
+                          (p) => p.type === "view-product-details",
+                        )?.image
+                      }
+                      alt="Product Details"
+                      className="w-full h-32 object-cover rounded-lg"
+                    />
+                  )}
+                  <Button
+                    onClick={() => {
+                      const popup = adminData.popups.find(
+                        (p) => p.type === "view-product-details",
+                      );
+                      if (popup?.buttonLink) {
+                        window.open(popup.buttonLink, "_blank");
+                      }
+                      setShowViewDetailsPopup(false);
+                    }}
+                    className="w-full"
+                  >
+                    {
+                      adminData.popups.find(
+                        (p) => p.type === "view-product-details",
+                      )?.buttonText
+                    }
+                  </Button>
+                </div>
+              </DialogContent>
+            </DialogPortal>
+          </Dialog>
+        )}
+
         {/* Exit Intent Popup */}
         {showExitIntent && (
           <ExitIntentPopup

--- a/client/components/admin/AdminLayout.tsx
+++ b/client/components/admin/AdminLayout.tsx
@@ -76,7 +76,7 @@ const sidebarItems = [
     id: "popups",
     label: "Popups",
     icon: Megaphone,
-    description: "Button-triggered and exit-intent popups",
+    description: "View product details and exit-intent popups",
   },
 ];
 

--- a/client/components/admin/FormComponents.tsx
+++ b/client/components/admin/FormComponents.tsx
@@ -459,3 +459,102 @@ export function FormSection({
     </div>
   );
 }
+
+// Switch Field
+interface SwitchFieldProps {
+  label: string;
+  description?: string;
+  value: boolean;
+  onChange: (value: boolean) => void;
+  className?: string;
+}
+
+export function SwitchField({
+  label,
+  description,
+  value,
+  onChange,
+  className,
+}: SwitchFieldProps) {
+  return (
+    <div className={cn("flex items-center justify-between space-x-2", className)}>
+      <div className="space-y-0.5">
+        <Label className="text-base">{label}</Label>
+        {description && (
+          <p className="text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+      <Switch checked={value} onCheckedChange={onChange} />
+    </div>
+  );
+}
+
+// Array Field (for managing lists of strings)
+interface ArrayFieldProps {
+  label: string;
+  value: string[];
+  onChange: (value: string[]) => void;
+  placeholder?: string;
+  addButtonText?: string;
+  className?: string;
+}
+
+export function ArrayField({
+  label,
+  value,
+  onChange,
+  placeholder = "Enter text",
+  addButtonText = "Add Item",
+  className,
+}: ArrayFieldProps) {
+  const addItem = () => {
+    onChange([...value, ""]);
+  };
+
+  const updateItem = (index: number, newValue: string) => {
+    const newArray = [...value];
+    newArray[index] = newValue;
+    onChange(newArray);
+  };
+
+  const removeItem = (index: number) => {
+    const newArray = value.filter((_, i) => i !== index);
+    onChange(newArray);
+  };
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      <Label>{label}</Label>
+
+      {value.map((item, index) => (
+        <div key={index} className="flex gap-2">
+          <Input
+            value={item}
+            onChange={(e) => updateItem(index, e.target.value)}
+            placeholder={`${placeholder} ${index + 1}`}
+            className="flex-1"
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => removeItem(index)}
+            className="text-red-600 hover:text-red-700 hover:bg-red-50"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      ))}
+
+      <Button
+        type="button"
+        variant="outline"
+        onClick={addItem}
+        className="w-full"
+      >
+        <Plus className="h-4 w-4 mr-2" />
+        {addButtonText}
+      </Button>
+    </div>
+  );
+}

--- a/client/components/admin/FormComponents.tsx
+++ b/client/components/admin/FormComponents.tsx
@@ -4,7 +4,15 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
-import { Upload, X, Save, RotateCcw, Loader2, Plus, Trash2 } from "lucide-react";
+import {
+  Upload,
+  X,
+  Save,
+  RotateCcw,
+  Loader2,
+  Plus,
+  Trash2,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { uploadImage, deleteImage } from "@/lib/supabase-admin";
 
@@ -477,7 +485,9 @@ export function SwitchField({
   className,
 }: SwitchFieldProps) {
   return (
-    <div className={cn("flex items-center justify-between space-x-2", className)}>
+    <div
+      className={cn("flex items-center justify-between space-x-2", className)}
+    >
       <div className="space-y-0.5">
         <Label className="text-base">{label}</Label>
         {description && (

--- a/client/components/admin/FormComponents.tsx
+++ b/client/components/admin/FormComponents.tsx
@@ -162,7 +162,8 @@ export function ImageUpload({
       // Generate a unique path for the image
       const fileExt = file.name.split(".").pop();
       const uniqueId = Math.random().toString(36).substring(2, 11);
-      const path = `admin_${Date.now()}_${uniqueId}`;
+      const timestamp = Date.now();
+      const path = `admin_${timestamp}_${uniqueId}`;
 
       console.log("Uploading file:", file.name, "to path:", path);
 
@@ -170,19 +171,20 @@ export function ImageUpload({
       const uploadedUrl = await uploadImage(file, path);
 
       if (uploadedUrl) {
-        console.log("Upload successful, URL:", uploadedUrl);
-        onChange(uploadedUrl);
+        // Add cache-busting parameter for cross-browser consistency
+        const urlWithCacheBusting = `${uploadedUrl}?v=${timestamp}`;
+        console.log("Upload successful, URL with cache-busting:", urlWithCacheBusting);
+        onChange(urlWithCacheBusting);
       } else {
         console.error("Upload failed: uploadImage returned null");
-        // Fallback to blob URL for local preview
-        const blobUrl = URL.createObjectURL(file);
-        onChange(blobUrl);
+        throw new Error("Image upload to Supabase failed - cross-browser sync requires cloud storage");
       }
     } catch (error) {
       console.error("Upload error:", error);
-      // Fallback to blob URL for local preview
-      const blobUrl = URL.createObjectURL(file);
-      onChange(blobUrl);
+      setIsUploading(false);
+      // Don't create blob URLs - they don't work across browsers
+      alert("Image upload failed. Please try again or check your internet connection. Cross-browser sync requires successful upload to cloud storage.");
+      return;
     } finally {
       setIsUploading(false);
     }

--- a/client/components/admin/FormComponents.tsx
+++ b/client/components/admin/FormComponents.tsx
@@ -3,7 +3,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Upload, X, Save, RotateCcw, Loader2 } from "lucide-react";
+import { Switch } from "@/components/ui/switch";
+import { Upload, X, Save, RotateCcw, Loader2, Plus, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { uploadImage, deleteImage } from "@/lib/supabase-admin";
 

--- a/client/components/admin/HeroForm.tsx
+++ b/client/components/admin/HeroForm.tsx
@@ -218,7 +218,6 @@ export function HeroForm() {
             placeholder="Learn More About This Product"
             required
           />
-
         </div>
       </FormSection>
 

--- a/client/components/admin/HeroForm.tsx
+++ b/client/components/admin/HeroForm.tsx
@@ -28,7 +28,6 @@ export function HeroForm() {
     stockText: "",
     primaryButtonText: "",
     secondaryButtonText: "",
-    specialOfferButtonText: "",
     productImages: [],
   });
   const [isSaving, setIsSaving] = useState(false);
@@ -220,13 +219,6 @@ export function HeroForm() {
             required
           />
 
-          <TextField
-            label="Special Offer Button Text"
-            value={heroData.specialOfferButtonText}
-            onChange={(value) => updateField("specialOfferButtonText", value)}
-            placeholder="🎁 Special Offer Available"
-            required
-          />
         </div>
       </FormSection>
 
@@ -346,9 +338,6 @@ export function HeroForm() {
               </div>
               <div className="border-2 border-blue-600 text-blue-600 px-6 py-3 rounded-lg text-center font-semibold">
                 {heroData.secondaryButtonText || "Secondary Button"}
-              </div>
-              <div className="text-blue-600 text-sm text-center font-medium">
-                {heroData.specialOfferButtonText || "Special Offer Button"}
               </div>
             </div>
 

--- a/client/components/admin/PopupsForm.tsx
+++ b/client/components/admin/PopupsForm.tsx
@@ -220,65 +220,249 @@ export function PopupsForm() {
                   </Button>
                 </div>
 
-                <TextField
-                  label="Popup Title"
-                  value={viewDetailsPopup.title}
-                  onChange={(value) =>
-                    updatePopup(viewDetailsPopup.id, "title", value)
-                  }
-                  placeholder="Nutritious Snack Box Details"
-                  required
-                />
+                {/* Header Configuration */}
+                <FormSection
+                  title="Header Configuration"
+                  description="Configure the popup header content."
+                >
+                  <SwitchField
+                    label="Use Hero Title"
+                    description="If enabled, uses the main product title from the hero section instead of the custom title below"
+                    value={viewDetailsPopup.useHeroTitle || false}
+                    onChange={(value) =>
+                      updatePopup(viewDetailsPopup.id, "useHeroTitle", value)
+                    }
+                  />
 
-                <TextAreaField
-                  label="Popup Description"
-                  value={viewDetailsPopup.description}
-                  onChange={(value) =>
-                    updatePopup(viewDetailsPopup.id, "description", value)
-                  }
-                  placeholder="Get detailed information about our 42-count nutritious snack box with premium breakfast bars and delicious chips."
-                  rows={3}
-                  required
-                />
+                  <TextField
+                    label="Custom Popup Title"
+                    value={viewDetailsPopup.title}
+                    onChange={(value) =>
+                      updatePopup(viewDetailsPopup.id, "title", value)
+                    }
+                    placeholder="Product Details"
+                    required={!viewDetailsPopup.useHeroTitle}
+                  />
 
-                <TextField
-                  label="Button Text"
-                  value={viewDetailsPopup.buttonText}
-                  onChange={(value) =>
-                    updatePopup(viewDetailsPopup.id, "buttonText", value)
-                  }
-                  placeholder="Buy Now on Walmart"
-                  required
-                />
+                  <TextAreaField
+                    label="Popup Description"
+                    value={viewDetailsPopup.description}
+                    onChange={(value) =>
+                      updatePopup(viewDetailsPopup.id, "description", value)
+                    }
+                    placeholder="View detailed product information, pricing, and purchase options for this 42-piece snack collection."
+                    rows={2}
+                    required
+                  />
+                </FormSection>
 
-                <TextField
-                  label="Button Link/Action"
-                  value={viewDetailsPopup.buttonLink}
-                  onChange={(value) =>
-                    updatePopup(viewDetailsPopup.id, "buttonLink", value)
-                  }
-                  placeholder="https://www.walmart.com/ip/product-page"
-                  required
-                />
+                {/* Content Sections */}
+                <FormSection
+                  title="Content Sections"
+                  description="Choose which sections to display in the popup."
+                >
+                  <SwitchField
+                    label="Show Product Images"
+                    description="Display product images with gallery navigation"
+                    value={viewDetailsPopup.showImages || false}
+                    onChange={(value) =>
+                      updatePopup(viewDetailsPopup.id, "showImages", value)
+                    }
+                  />
 
-                <ImageUpload
-                  label="Popup Image (Optional)"
-                  value={viewDetailsPopup.image || ""}
-                  onChange={(value) =>
-                    updatePopup(viewDetailsPopup.id, "image", value)
-                  }
-                  placeholder="Upload an image for the popup"
-                />
+                  <SwitchField
+                    label="Show Rating"
+                    description="Display star rating and review count"
+                    value={viewDetailsPopup.showRating || false}
+                    onChange={(value) =>
+                      updatePopup(viewDetailsPopup.id, "showRating", value)
+                    }
+                  />
+
+                  <SwitchField
+                    label="Show Pricing"
+                    description="Display sale price, original price, and special offers"
+                    value={viewDetailsPopup.showPricing || false}
+                    onChange={(value) =>
+                      updatePopup(viewDetailsPopup.id, "showPricing", value)
+                    }
+                  />
+
+                  {viewDetailsPopup.showPricing && (
+                    <div className="ml-6 space-y-4 border-l-2 border-blue-200 pl-4">
+                      <TextField
+                        label="Subscribe & Save Text"
+                        value={viewDetailsPopup.subscribeText || ""}
+                        onChange={(value) =>
+                          updatePopup(viewDetailsPopup.id, "subscribeText", value)
+                        }
+                        placeholder="✓ Subscribe & Save available"
+                      />
+
+                      <TextField
+                        label="Walmart+ Text"
+                        value={viewDetailsPopup.walmartText || ""}
+                        onChange={(value) =>
+                          updatePopup(viewDetailsPopup.id, "walmartText", value)
+                        }
+                        placeholder="✓ Walmart+ offer eligible"
+                      />
+                    </div>
+                  )}
+
+                  <SwitchField
+                    label="Show Pieces Count"
+                    description="Display the number of items in the package"
+                    value={viewDetailsPopup.showPiecesCount || false}
+                    onChange={(value) =>
+                      updatePopup(viewDetailsPopup.id, "showPiecesCount", value)
+                    }
+                  />
+
+                  {viewDetailsPopup.showPiecesCount && (
+                    <div className="ml-6 space-y-4 border-l-2 border-blue-200 pl-4">
+                      <NumberField
+                        label="Pieces Count"
+                        value={viewDetailsPopup.piecesCount || 42}
+                        onChange={(value) =>
+                          updatePopup(viewDetailsPopup.id, "piecesCount", value)
+                        }
+                        min={1}
+                        placeholder="42"
+                      />
+
+                      <TextField
+                        label="Pieces Count Title"
+                        value={viewDetailsPopup.piecesCountTitle || ""}
+                        onChange={(value) =>
+                          updatePopup(viewDetailsPopup.id, "piecesCountTitle", value)
+                        }
+                        placeholder="Pieces Count:"
+                      />
+
+                      <TextField
+                        label="Pieces Count Subtitle"
+                        value={viewDetailsPopup.piecesCountSubtitle || ""}
+                        onChange={(value) =>
+                          updatePopup(viewDetailsPopup.id, "piecesCountSubtitle", value)
+                        }
+                        placeholder="Perfect variety for extended enjoyment"
+                      />
+                    </div>
+                  )}
+
+                  <SwitchField
+                    label="Show More Details"
+                    description="Display a detailed list of product features"
+                    value={viewDetailsPopup.showMoreDetails || false}
+                    onChange={(value) =>
+                      updatePopup(viewDetailsPopup.id, "showMoreDetails", value)
+                    }
+                  />
+
+                  {viewDetailsPopup.showMoreDetails && (
+                    <div className="ml-6 space-y-4 border-l-2 border-blue-200 pl-4">
+                      <TextField
+                        label="More Details Title"
+                        value={viewDetailsPopup.moreDetailsTitle || ""}
+                        onChange={(value) =>
+                          updatePopup(viewDetailsPopup.id, "moreDetailsTitle", value)
+                        }
+                        placeholder="More Details"
+                      />
+
+                      <ArrayField
+                        label="Detail Items"
+                        value={viewDetailsPopup.moreDetails || []}
+                        onChange={(value) =>
+                          updatePopup(viewDetailsPopup.id, "moreDetails", value)
+                        }
+                        placeholder="Enter detail"
+                        addButtonText="Add Detail"
+                      />
+                    </div>
+                  )}
+                </FormSection>
+
+                {/* Button Configuration */}
+                <FormSection
+                  title="Button Configuration"
+                  description="Configure the action buttons at the bottom of the popup."
+                >
+                  <TextField
+                    label="Primary Button Text"
+                    value={viewDetailsPopup.primaryButtonText || viewDetailsPopup.buttonText}
+                    onChange={(value) =>
+                      updatePopup(viewDetailsPopup.id, "primaryButtonText", value)
+                    }
+                    placeholder="Buy Now on Walmart"
+                    required
+                  />
+
+                  <TextField
+                    label="Primary Button Link"
+                    value={viewDetailsPopup.primaryButtonLink || viewDetailsPopup.buttonLink}
+                    onChange={(value) =>
+                      updatePopup(viewDetailsPopup.id, "primaryButtonLink", value)
+                    }
+                    placeholder="https://www.walmart.com/ip/product-page"
+                    required
+                  />
+
+                  <TextField
+                    label="Secondary Button Text"
+                    value={viewDetailsPopup.secondaryButtonText || ""}
+                    onChange={(value) =>
+                      updatePopup(viewDetailsPopup.id, "secondaryButtonText", value)
+                    }
+                    placeholder="Continue Browsing"
+                  />
+                </FormSection>
+
+                {/* Legacy Fields (for compatibility) */}
+                <FormSection
+                  title="Legacy Compatibility"
+                  description="These fields are maintained for compatibility with the simple popup fallback."
+                >
+                  <TextField
+                    label="Legacy Button Text"
+                    value={viewDetailsPopup.buttonText}
+                    onChange={(value) =>
+                      updatePopup(viewDetailsPopup.id, "buttonText", value)
+                    }
+                    placeholder="Buy Now on Walmart"
+                    required
+                  />
+
+                  <TextField
+                    label="Legacy Button Link"
+                    value={viewDetailsPopup.buttonLink}
+                    onChange={(value) =>
+                      updatePopup(viewDetailsPopup.id, "buttonLink", value)
+                    }
+                    placeholder="https://www.walmart.com/ip/product-page"
+                    required
+                  />
+
+                  <ImageUpload
+                    label="Legacy Popup Image (Optional)"
+                    value={viewDetailsPopup.image || ""}
+                    onChange={(value) =>
+                      updatePopup(viewDetailsPopup.id, "image", value)
+                    }
+                    placeholder="Upload an image for the popup"
+                  />
+                </FormSection>
 
                 <div className="bg-blue-50 p-4 rounded-lg">
                   <div className="text-sm font-medium text-blue-900 mb-2">
-                    Usage Tips:
+                    Configuration Tips:
                   </div>
                   <ul className="text-sm text-blue-800 space-y-1">
-                    <li>• Use descriptive titles that clearly indicate product details</li>
-                    <li>• Include comprehensive product information in the description</li>
-                    <li>• Use direct product or purchase links for the button action</li>
-                    <li>• Add product images to help users visualize the items</li>
+                    <li>• Enable "Use Hero Title" to automatically use the main product title</li>
+                    <li>• Toggle content sections to match the frontend modal exactly</li>
+                    <li>• More Details section supports multiple bullet points</li>
+                    <li>• Primary button leads to purchase, secondary button closes popup</li>
                   </ul>
                 </div>
               </div>

--- a/client/components/admin/PopupsForm.tsx
+++ b/client/components/admin/PopupsForm.tsx
@@ -30,25 +30,25 @@ export function PopupsForm() {
       const popupsData = adminData.popups || [];
 
       // Check if we have required popup types, if not create them
-      const buttonPopup = popupsData.find((p) => p.type === "button-triggered");
+      const viewDetailsPopup = popupsData.find((p) => p.type === "view-product-details");
       const exitPopup = popupsData.find((p) => p.type === "exit-intent");
 
       const requiredPopups = [];
 
-      if (!buttonPopup) {
+      if (!viewDetailsPopup) {
         requiredPopups.push({
-          id: "button-popup",
-          title: "Special Offer!",
+          id: "view-details-popup",
+          title: "Nutritious Snack Box Details",
           description:
-            "Get 10% off your first order when you subscribe to our newsletter.",
-          buttonText: "Get My Discount",
+            "Get detailed information about our 42-count nutritious snack box with premium breakfast bars and delicious chips.",
+          buttonText: "Buy Now on Walmart",
           buttonLink:
-            "mailto:subscribe@example.com?subject=Newsletter%20Subscription",
+            "https://www.walmart.com/ip/Healthy-Snack-Box-Tasty-Nutrient-Rich-Variety-42-Count-by-Gift-A-Snack/14479818419",
           image: "",
-          type: "button-triggered" as const,
+          type: "view-product-details" as const,
         });
       } else {
-        requiredPopups.push(buttonPopup);
+        requiredPopups.push(viewDetailsPopup);
       }
 
       if (!exitPopup) {
@@ -102,11 +102,11 @@ export function PopupsForm() {
     );
   };
 
-  const getPopupByType = (type: "button-triggered" | "exit-intent") => {
+  const getPopupByType = (type: "view-product-details" | "exit-intent") => {
     return popups.find((popup) => popup.type === type);
   };
 
-  const buttonPopup = getPopupByType("button-triggered");
+  const viewDetailsPopup = getPopupByType("view-product-details");
   const exitPopup = getPopupByType("exit-intent");
 
   const PopupPreview = ({ popup }: { popup: PopupData }) => (
@@ -150,7 +150,7 @@ export function PopupsForm() {
     <>
       <SectionHeader
         title="Popups Management"
-        description="Configure your marketing popups: button-triggered popups for engagement and exit-intent popups for retention."
+        description="Configure your marketing popups: view product details popup for product information and exit-intent popups for retention."
         actions={
           <div className="flex items-center gap-2 text-sm text-gray-500">
             <Megaphone className="h-4 w-4" />
@@ -159,14 +159,14 @@ export function PopupsForm() {
         }
       />
 
-      <Tabs defaultValue="button-triggered" className="space-y-6">
+      <Tabs defaultValue="view-product-details" className="space-y-6">
         <TabsList className="grid w-full grid-cols-2">
           <TabsTrigger
-            value="button-triggered"
+            value="view-product-details"
             className="flex items-center gap-2"
           >
-            <MousePointer className="h-4 w-4" />
-            Button-Triggered Popup
+            <Eye className="h-4 w-4" />
+            View Product Details Popup
           </TabsTrigger>
           <TabsTrigger value="exit-intent" className="flex items-center gap-2">
             <ExternalLink className="h-4 w-4" />
@@ -174,23 +174,23 @@ export function PopupsForm() {
           </TabsTrigger>
         </TabsList>
 
-        {/* Button-Triggered Popup */}
-        <TabsContent value="button-triggered">
+        {/* View Product Details Popup */}
+        <TabsContent value="view-product-details">
           <FormSection
-            title="Button-Triggered Popup"
-            description="This popup appears when users click a specific button or trigger. Great for special offers, newsletter signups, or detailed information."
+            title="View Product Details Popup"
+            description="This popup appears when users click the 'View Product Details' button. Shows comprehensive product information, pricing, and purchase options."
           >
-            {buttonPopup && (
+            {viewDetailsPopup && (
               <div className="space-y-6">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2 text-sm text-gray-600">
-                    <MousePointer className="h-4 w-4" />
-                    <span>Triggered by button clicks</span>
+                    <Eye className="h-4 w-4" />
+                    <span>Triggered by 'View Product Details' button</span>
                   </div>
                   <Button
                     variant="outline"
                     size="sm"
-                    onClick={() => setPreviewPopup("button-triggered")}
+                    onClick={() => setPreviewPopup("view-product-details")}
                   >
                     <Eye className="h-4 w-4 mr-2" />
                     Preview
@@ -199,50 +199,50 @@ export function PopupsForm() {
 
                 <TextField
                   label="Popup Title"
-                  value={buttonPopup.title}
+                  value={viewDetailsPopup.title}
                   onChange={(value) =>
-                    updatePopup(buttonPopup.id, "title", value)
+                    updatePopup(viewDetailsPopup.id, "title", value)
                   }
-                  placeholder="Special Offer!"
+                  placeholder="Nutritious Snack Box Details"
                   required
                 />
 
                 <TextAreaField
                   label="Popup Description"
-                  value={buttonPopup.description}
+                  value={viewDetailsPopup.description}
                   onChange={(value) =>
-                    updatePopup(buttonPopup.id, "description", value)
+                    updatePopup(viewDetailsPopup.id, "description", value)
                   }
-                  placeholder="Get 10% off your first order when you subscribe to our newsletter."
+                  placeholder="Get detailed information about our 42-count nutritious snack box with premium breakfast bars and delicious chips."
                   rows={3}
                   required
                 />
 
                 <TextField
                   label="Button Text"
-                  value={buttonPopup.buttonText}
+                  value={viewDetailsPopup.buttonText}
                   onChange={(value) =>
-                    updatePopup(buttonPopup.id, "buttonText", value)
+                    updatePopup(viewDetailsPopup.id, "buttonText", value)
                   }
-                  placeholder="Get My Discount"
+                  placeholder="Buy Now on Walmart"
                   required
                 />
 
                 <TextField
                   label="Button Link/Action"
-                  value={buttonPopup.buttonLink}
+                  value={viewDetailsPopup.buttonLink}
                   onChange={(value) =>
-                    updatePopup(buttonPopup.id, "buttonLink", value)
+                    updatePopup(viewDetailsPopup.id, "buttonLink", value)
                   }
-                  placeholder="mailto:subscribe@example.com or https://signup-page.com"
+                  placeholder="https://www.walmart.com/ip/product-page"
                   required
                 />
 
                 <ImageUpload
                   label="Popup Image (Optional)"
-                  value={buttonPopup.image || ""}
+                  value={viewDetailsPopup.image || ""}
                   onChange={(value) =>
-                    updatePopup(buttonPopup.id, "image", value)
+                    updatePopup(viewDetailsPopup.id, "image", value)
                   }
                   placeholder="Upload an image for the popup"
                 />
@@ -252,12 +252,10 @@ export function PopupsForm() {
                     Usage Tips:
                   </div>
                   <ul className="text-sm text-blue-800 space-y-1">
-                    <li>• Use compelling titles that create urgency</li>
-                    <li>• Keep descriptions concise but persuasive</li>
-                    <li>
-                      • For email links, use format: mailto:email@domain.com
-                    </li>
-                    <li>• For web links, include full URL with https://</li>
+                    <li>• Use descriptive titles that clearly indicate product details</li>
+                    <li>• Include comprehensive product information in the description</li>
+                    <li>• Use direct product or purchase links for the button action</li>
+                    <li>• Add product images to help users visualize the items</li>
                   </ul>
                 </div>
               </div>
@@ -377,7 +375,7 @@ export function PopupsForm() {
       {previewPopup && (
         <PopupPreview
           popup={
-            previewPopup === "button-triggered" ? buttonPopup! : exitPopup!
+            previewPopup === "view-product-details" ? viewDetailsPopup! : exitPopup!
           }
         />
       )}

--- a/client/components/admin/PopupsForm.tsx
+++ b/client/components/admin/PopupsForm.tsx
@@ -33,7 +33,9 @@ export function PopupsForm() {
       const popupsData = adminData.popups || [];
 
       // Check if we have required popup types, if not create them
-      const viewDetailsPopup = popupsData.find((p) => p.type === "view-product-details");
+      const viewDetailsPopup = popupsData.find(
+        (p) => p.type === "view-product-details",
+      );
       const exitPopup = popupsData.find((p) => p.type === "exit-intent");
 
       const requiredPopups = [];
@@ -42,9 +44,11 @@ export function PopupsForm() {
         requiredPopups.push({
           id: "view-details-popup",
           title: "Product Details",
-          description: "View detailed product information, pricing, and purchase options for this 42-piece snack collection.",
+          description:
+            "View detailed product information, pricing, and purchase options for this 42-piece snack collection.",
           buttonText: "Buy Now on Walmart",
-          buttonLink: "https://www.walmart.com/ip/Healthy-Snack-Box-Tasty-Nutrient-Rich-Variety-42-Count-by-Gift-A-Snack/14479818419",
+          buttonLink:
+            "https://www.walmart.com/ip/Healthy-Snack-Box-Tasty-Nutrient-Rich-Variety-42-Count-by-Gift-A-Snack/14479818419",
           image: "",
           type: "view-product-details" as const,
           useHeroTitle: true,
@@ -62,13 +66,14 @@ export function PopupsForm() {
             "Packed with a variety of breakfast bars and savory snacks for daily energy",
             "Individually packaged snacks for convenient grab-and-go options",
             "Ideal for adults, teens, and college students alike",
-            "Arrives with a heartwarming greeting card for a personal touch"
+            "Arrives with a heartwarming greeting card for a personal touch",
           ],
           primaryButtonText: "Buy Now on Walmart",
-          primaryButtonLink: "https://www.walmart.com/ip/Healthy-Snack-Box-Tasty-Nutrient-Rich-Variety-42-Count-by-Gift-A-Snack/14479818419",
+          primaryButtonLink:
+            "https://www.walmart.com/ip/Healthy-Snack-Box-Tasty-Nutrient-Rich-Variety-42-Count-by-Gift-A-Snack/14479818419",
           secondaryButtonText: "Continue Browsing",
           subscribeText: "✓ Subscribe & Save available",
-          walmartText: "✓ Walmart+ offer eligible"
+          walmartText: "✓ Walmart+ offer eligible",
         });
       } else {
         requiredPopups.push(viewDetailsPopup);
@@ -113,11 +118,7 @@ export function PopupsForm() {
     setPopups(adminData.popups);
   };
 
-  const updatePopup = (
-    popupId: string,
-    field: keyof PopupData,
-    value: any,
-  ) => {
+  const updatePopup = (popupId: string, field: keyof PopupData, value: any) => {
     setPopups((prev) =>
       prev.map((popup) =>
         popup.id === popupId ? { ...popup, [field]: value } : popup,
@@ -294,7 +295,11 @@ export function PopupsForm() {
                         label="Subscribe & Save Text"
                         value={viewDetailsPopup.subscribeText || ""}
                         onChange={(value) =>
-                          updatePopup(viewDetailsPopup.id, "subscribeText", value)
+                          updatePopup(
+                            viewDetailsPopup.id,
+                            "subscribeText",
+                            value,
+                          )
                         }
                         placeholder="✓ Subscribe & Save available"
                       />
@@ -335,7 +340,11 @@ export function PopupsForm() {
                         label="Pieces Count Title"
                         value={viewDetailsPopup.piecesCountTitle || ""}
                         onChange={(value) =>
-                          updatePopup(viewDetailsPopup.id, "piecesCountTitle", value)
+                          updatePopup(
+                            viewDetailsPopup.id,
+                            "piecesCountTitle",
+                            value,
+                          )
                         }
                         placeholder="Pieces Count:"
                       />
@@ -344,7 +353,11 @@ export function PopupsForm() {
                         label="Pieces Count Subtitle"
                         value={viewDetailsPopup.piecesCountSubtitle || ""}
                         onChange={(value) =>
-                          updatePopup(viewDetailsPopup.id, "piecesCountSubtitle", value)
+                          updatePopup(
+                            viewDetailsPopup.id,
+                            "piecesCountSubtitle",
+                            value,
+                          )
                         }
                         placeholder="Perfect variety for extended enjoyment"
                       />
@@ -366,7 +379,11 @@ export function PopupsForm() {
                         label="More Details Title"
                         value={viewDetailsPopup.moreDetailsTitle || ""}
                         onChange={(value) =>
-                          updatePopup(viewDetailsPopup.id, "moreDetailsTitle", value)
+                          updatePopup(
+                            viewDetailsPopup.id,
+                            "moreDetailsTitle",
+                            value,
+                          )
                         }
                         placeholder="More Details"
                       />
@@ -391,9 +408,16 @@ export function PopupsForm() {
                 >
                   <TextField
                     label="Primary Button Text"
-                    value={viewDetailsPopup.primaryButtonText || viewDetailsPopup.buttonText}
+                    value={
+                      viewDetailsPopup.primaryButtonText ||
+                      viewDetailsPopup.buttonText
+                    }
                     onChange={(value) =>
-                      updatePopup(viewDetailsPopup.id, "primaryButtonText", value)
+                      updatePopup(
+                        viewDetailsPopup.id,
+                        "primaryButtonText",
+                        value,
+                      )
                     }
                     placeholder="Buy Now on Walmart"
                     required
@@ -401,9 +425,16 @@ export function PopupsForm() {
 
                   <TextField
                     label="Primary Button Link"
-                    value={viewDetailsPopup.primaryButtonLink || viewDetailsPopup.buttonLink}
+                    value={
+                      viewDetailsPopup.primaryButtonLink ||
+                      viewDetailsPopup.buttonLink
+                    }
                     onChange={(value) =>
-                      updatePopup(viewDetailsPopup.id, "primaryButtonLink", value)
+                      updatePopup(
+                        viewDetailsPopup.id,
+                        "primaryButtonLink",
+                        value,
+                      )
                     }
                     placeholder="https://www.walmart.com/ip/product-page"
                     required
@@ -413,7 +444,11 @@ export function PopupsForm() {
                     label="Secondary Button Text"
                     value={viewDetailsPopup.secondaryButtonText || ""}
                     onChange={(value) =>
-                      updatePopup(viewDetailsPopup.id, "secondaryButtonText", value)
+                      updatePopup(
+                        viewDetailsPopup.id,
+                        "secondaryButtonText",
+                        value,
+                      )
                     }
                     placeholder="Continue Browsing"
                   />
@@ -459,10 +494,21 @@ export function PopupsForm() {
                     Configuration Tips:
                   </div>
                   <ul className="text-sm text-blue-800 space-y-1">
-                    <li>• Enable "Use Hero Title" to automatically use the main product title</li>
-                    <li>• Toggle content sections to match the frontend modal exactly</li>
-                    <li>• More Details section supports multiple bullet points</li>
-                    <li>• Primary button leads to purchase, secondary button closes popup</li>
+                    <li>
+                      • Enable "Use Hero Title" to automatically use the main
+                      product title
+                    </li>
+                    <li>
+                      • Toggle content sections to match the frontend modal
+                      exactly
+                    </li>
+                    <li>
+                      • More Details section supports multiple bullet points
+                    </li>
+                    <li>
+                      • Primary button leads to purchase, secondary button
+                      closes popup
+                    </li>
                   </ul>
                 </div>
               </div>
@@ -582,7 +628,9 @@ export function PopupsForm() {
       {previewPopup && (
         <PopupPreview
           popup={
-            previewPopup === "view-product-details" ? viewDetailsPopup! : exitPopup!
+            previewPopup === "view-product-details"
+              ? viewDetailsPopup!
+              : exitPopup!
           }
         />
       )}

--- a/client/components/admin/PopupsForm.tsx
+++ b/client/components/admin/PopupsForm.tsx
@@ -41,14 +41,34 @@ export function PopupsForm() {
       if (!viewDetailsPopup) {
         requiredPopups.push({
           id: "view-details-popup",
-          title: "Nutritious Snack Box Details",
-          description:
-            "Get detailed information about our 42-count nutritious snack box with premium breakfast bars and delicious chips.",
+          title: "Product Details",
+          description: "View detailed product information, pricing, and purchase options for this 42-piece snack collection.",
           buttonText: "Buy Now on Walmart",
-          buttonLink:
-            "https://www.walmart.com/ip/Healthy-Snack-Box-Tasty-Nutrient-Rich-Variety-42-Count-by-Gift-A-Snack/14479818419",
+          buttonLink: "https://www.walmart.com/ip/Healthy-Snack-Box-Tasty-Nutrient-Rich-Variety-42-Count-by-Gift-A-Snack/14479818419",
           image: "",
           type: "view-product-details" as const,
+          useHeroTitle: true,
+          showImages: true,
+          showRating: true,
+          showPricing: true,
+          showPiecesCount: true,
+          piecesCount: 42,
+          piecesCountTitle: "Pieces Count:",
+          piecesCountSubtitle: "Perfect variety for extended enjoyment",
+          showMoreDetails: true,
+          moreDetailsTitle: "More Details",
+          moreDetails: [
+            "Ultimate snack experience in a beautifully designed high-end packaging box",
+            "Packed with a variety of breakfast bars and savory snacks for daily energy",
+            "Individually packaged snacks for convenient grab-and-go options",
+            "Ideal for adults, teens, and college students alike",
+            "Arrives with a heartwarming greeting card for a personal touch"
+          ],
+          primaryButtonText: "Buy Now on Walmart",
+          primaryButtonLink: "https://www.walmart.com/ip/Healthy-Snack-Box-Tasty-Nutrient-Rich-Variety-42-Count-by-Gift-A-Snack/14479818419",
+          secondaryButtonText: "Continue Browsing",
+          subscribeText: "✓ Subscribe & Save available",
+          walmartText: "✓ Walmart+ offer eligible"
         });
       } else {
         requiredPopups.push(viewDetailsPopup);

--- a/client/components/admin/PopupsForm.tsx
+++ b/client/components/admin/PopupsForm.tsx
@@ -5,6 +5,9 @@ import {
   ImageUpload,
   ActionButtons,
   FormSection,
+  SwitchField,
+  ArrayField,
+  NumberField,
 } from "./FormComponents";
 import { SectionHeader, SuccessToast } from "./AdminLayout";
 import {

--- a/client/components/admin/PopupsForm.tsx
+++ b/client/components/admin/PopupsForm.tsx
@@ -116,7 +116,7 @@ export function PopupsForm() {
   const updatePopup = (
     popupId: string,
     field: keyof PopupData,
-    value: string,
+    value: any,
   ) => {
     setPopups((prev) =>
       prev.map((popup) =>

--- a/client/components/ui/command.tsx
+++ b/client/components/ui/command.tsx
@@ -4,7 +4,7 @@ import { Command as CommandPrimitive } from "cmdk";
 import { Search } from "lucide-react";
 
 import { cn } from "@/lib/utils";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,

--- a/client/components/ui/command.tsx
+++ b/client/components/ui/command.tsx
@@ -27,6 +27,7 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
+        <DialogTitle className="sr-only">Command Menu</DialogTitle>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/client/lib/admin-storage-supabase.ts
+++ b/client/lib/admin-storage-supabase.ts
@@ -62,14 +62,17 @@ async function ensureConnection(): Promise<boolean> {
   }
 }
 
-// Get admin data with fallback to localStorage
+// Get admin data from Supabase only (no localStorage fallback for cross-browser sync)
 export async function getAdminData(): Promise<AdminData> {
   try {
     const connected = await ensureConnection();
 
     if (!connected) {
-      console.warn("Supabase not connected, using localStorage");
-      return getLocalStorageData();
+      console.error("Supabase not connected - cannot sync across browsers");
+      // Initialize Supabase with default data instead of using localStorage
+      console.log("Initializing Supabase with default data...");
+      await saveSupabaseAdminData(defaultAdminData);
+      return defaultAdminData;
     }
 
     // Try to get data from Supabase
@@ -114,19 +117,21 @@ export async function getAdminData(): Promise<AdminData> {
             supabaseData.footer?.socialLinks ||
             defaultAdminData.footer.socialLinks,
         },
+        popups: supabaseData.popups || defaultAdminData.popups,
         lastUpdated: supabaseData.lastUpdated || new Date().toISOString(),
       };
     } else {
-      // Fallback to localStorage if Supabase data not found
-      console.log("No Supabase data found, using localStorage fallback");
-      return getLocalStorageData();
+      // Initialize Supabase with default data if no data found
+      console.log("No Supabase data found, initializing with defaults");
+      await saveSupabaseAdminData(defaultAdminData);
+      return defaultAdminData;
     }
   } catch (error) {
     console.error(
       "Error fetching admin data:",
       error instanceof Error ? error.message : error,
     );
-    return getLocalStorageData();
+    throw new Error("Failed to load data from Supabase. Cross-browser sync requires Supabase connection.");
   }
 }
 

--- a/client/lib/admin-storage-supabase.ts
+++ b/client/lib/admin-storage-supabase.ts
@@ -207,7 +207,7 @@ function saveToLocalStorage(data: Partial<AdminData>): void {
   }
 }
 
-// Save specific section
+// Save specific section to Supabase only (no localStorage fallback for cross-browser sync)
 export async function saveSection<K extends keyof AdminData>(
   section: K,
   data: AdminData[K],
@@ -216,31 +216,23 @@ export async function saveSection<K extends keyof AdminData>(
     const connected = await ensureConnection();
 
     if (!connected) {
-      console.warn("Supabase not connected, saving to localStorage");
-      saveToLocalStorage({ [section]: data } as Partial<AdminData>);
-      return;
+      throw new Error(`Supabase not connected - cannot save ${section} for cross-browser sync`);
     }
 
     // Save to Supabase
     const success = await saveSupabaseSection(section, data);
 
     if (!success) {
-      console.warn(
-        "Failed to save section to Supabase, falling back to localStorage",
-      );
-      saveToLocalStorage({ [section]: data } as Partial<AdminData>);
-      throw new Error("Failed to save section to Supabase");
+      throw new Error(`Failed to save ${section} to Supabase - cross-browser sync requires Supabase`);
     }
 
-    console.log(`Successfully saved ${section} to Supabase`);
+    console.log(`Successfully saved ${section} to Supabase for cross-browser sync`);
   } catch (error) {
     console.error(
       `Error saving section ${section}:`,
       error instanceof Error ? error.message : error,
     );
-    // Fallback to localStorage
-    saveToLocalStorage({ [section]: data } as Partial<AdminData>);
-    throw new Error("Failed to save section");
+    throw error; // Don't fallback to localStorage - this prevents cross-browser sync
   }
 }
 

--- a/client/lib/admin-storage-supabase.ts
+++ b/client/lib/admin-storage-supabase.ts
@@ -163,35 +163,29 @@ function getLocalStorageData(): AdminData {
   return defaultAdminData;
 }
 
-// Save admin data with fallback to localStorage
+// Save admin data to Supabase only (no localStorage fallback for cross-browser sync)
 export async function saveAdminData(data: Partial<AdminData>): Promise<void> {
   try {
     const connected = await ensureConnection();
 
     if (!connected) {
-      console.warn("Supabase not connected, saving to localStorage");
-      saveToLocalStorage(data);
-      return;
+      throw new Error("Supabase not connected - cannot save data for cross-browser sync");
     }
 
     // Save to Supabase
     const success = await saveSupabaseAdminData(data);
 
     if (!success) {
-      console.warn("Failed to save to Supabase, falling back to localStorage");
-      saveToLocalStorage(data);
-      throw new Error("Failed to save to Supabase");
+      throw new Error("Failed to save to Supabase - cross-browser sync requires Supabase");
     }
 
-    console.log("Successfully saved data to Supabase");
+    console.log("Successfully saved data to Supabase for cross-browser sync");
   } catch (error) {
     console.error(
       "Error saving admin data:",
       error instanceof Error ? error.message : error,
     );
-    // Fallback to localStorage
-    saveToLocalStorage(data);
-    throw new Error("Failed to save data");
+    throw error; // Don't fallback to localStorage - this prevents cross-browser sync
   }
 }
 

--- a/client/lib/admin-storage.ts
+++ b/client/lib/admin-storage.ts
@@ -97,7 +97,7 @@ export interface PopupData {
   buttonText: string;
   buttonLink: string;
   image?: string;
-  type: "button-triggered" | "exit-intent";
+  type: "view-product-details" | "exit-intent";
 }
 
 export interface AdminData {
@@ -364,16 +364,16 @@ export const defaultAdminData: AdminData = {
   },
   popups: [
     {
-      id: "button-popup",
-      title: "Special Offer!",
+      id: "view-details-popup",
+      title: "Nutritious Snack Box Details",
       description:
-        "Get 10% off your first order when you subscribe to our newsletter.",
-      buttonText: "Get My Discount",
+        "Get detailed information about our 42-count nutritious snack box with premium breakfast bars and delicious chips.",
+      buttonText: "Buy Now on Walmart",
       buttonLink:
-        "mailto:subscribe@example.com?subject=Newsletter%20Subscription",
+        "https://www.walmart.com/ip/Healthy-Snack-Box-Tasty-Nutrient-Rich-Variety-42-Count-by-Gift-A-Snack/14479818419",
       image:
         "https://cdn.builder.io/api/v1/image/assets%2F84282e2d620247d2b8d8845fda2c790e%2F79d471e5bc56457eb2c3b1c3eb6586ae?format=webp&width=400",
-      type: "button-triggered",
+      type: "view-product-details",
     },
     {
       id: "exit-popup",

--- a/client/lib/admin-storage.ts
+++ b/client/lib/admin-storage.ts
@@ -383,10 +383,13 @@ export const defaultAdminData: AdminData = {
     {
       id: "view-details-popup",
       title: "Product Details", // This will be overridden by hero title
-      description: "View detailed product information, pricing, and purchase options for this 42-piece snack collection.",
+      description:
+        "View detailed product information, pricing, and purchase options for this 42-piece snack collection.",
       buttonText: "Buy Now on Walmart",
-      buttonLink: "https://www.walmart.com/ip/Healthy-Snack-Box-Tasty-Nutrient-Rich-Variety-42-Count-by-Gift-A-Snack/14479818419",
-      image: "https://cdn.builder.io/api/v1/image/assets%2F84282e2d620247d2b8d8845fda2c790e%2F79d471e5bc56457eb2c3b1c3eb6586ae?format=webp&width=400",
+      buttonLink:
+        "https://www.walmart.com/ip/Healthy-Snack-Box-Tasty-Nutrient-Rich-Variety-42-Count-by-Gift-A-Snack/14479818419",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F84282e2d620247d2b8d8845fda2c790e%2F79d471e5bc56457eb2c3b1c3eb6586ae?format=webp&width=400",
       type: "view-product-details",
       useHeroTitle: true,
       showImages: true,
@@ -403,13 +406,14 @@ export const defaultAdminData: AdminData = {
         "Packed with a variety of breakfast bars and savory snacks for daily energy",
         "Individually packaged snacks for convenient grab-and-go options",
         "Ideal for adults, teens, and college students alike",
-        "Arrives with a heartwarming greeting card for a personal touch"
+        "Arrives with a heartwarming greeting card for a personal touch",
       ],
       primaryButtonText: "Buy Now on Walmart",
-      primaryButtonLink: "https://www.walmart.com/ip/Healthy-Snack-Box-Tasty-Nutrient-Rich-Variety-42-Count-by-Gift-A-Snack/14479818419",
+      primaryButtonLink:
+        "https://www.walmart.com/ip/Healthy-Snack-Box-Tasty-Nutrient-Rich-Variety-42-Count-by-Gift-A-Snack/14479818419",
       secondaryButtonText: "Continue Browsing",
       subscribeText: "✓ Subscribe & Save available",
-      walmartText: "✓ Walmart+ offer eligible"
+      walmartText: "✓ Walmart+ offer eligible",
     },
     {
       id: "exit-popup",

--- a/client/lib/admin-storage.ts
+++ b/client/lib/admin-storage.ts
@@ -18,7 +18,6 @@ export interface HeroData {
   stockText: string;
   primaryButtonText: string;
   secondaryButtonText: string;
-  specialOfferButtonText: string;
   productImages: string[];
 }
 
@@ -140,7 +139,6 @@ export const defaultAdminData: AdminData = {
     stockText: "⚡ Limited stock available",
     primaryButtonText: "View Product Details",
     secondaryButtonText: "Learn More About This Product",
-    specialOfferButtonText: "🎁 Special Offer Available",
     productImages: [
       "https://cdn.builder.io/api/v1/image/assets%2F84282e2d620247d2b8d8845fda2c790e%2F79d471e5bc56457eb2c3b1c3eb6586ae?format=webp&width=800",
       "https://cdn.builder.io/api/v1/image/assets%2F84282e2d620247d2b8d8845fda2c790e%2F05b5599b733643de9ed02db80950feb9?format=webp&width=800",

--- a/client/lib/admin-storage.ts
+++ b/client/lib/admin-storage.ts
@@ -382,15 +382,34 @@ export const defaultAdminData: AdminData = {
   popups: [
     {
       id: "view-details-popup",
-      title: "Nutritious Snack Box Details",
-      description:
-        "Get detailed information about our 42-count nutritious snack box with premium breakfast bars and delicious chips.",
+      title: "Product Details", // This will be overridden by hero title
+      description: "View detailed product information, pricing, and purchase options for this 42-piece snack collection.",
       buttonText: "Buy Now on Walmart",
-      buttonLink:
-        "https://www.walmart.com/ip/Healthy-Snack-Box-Tasty-Nutrient-Rich-Variety-42-Count-by-Gift-A-Snack/14479818419",
-      image:
-        "https://cdn.builder.io/api/v1/image/assets%2F84282e2d620247d2b8d8845fda2c790e%2F79d471e5bc56457eb2c3b1c3eb6586ae?format=webp&width=400",
+      buttonLink: "https://www.walmart.com/ip/Healthy-Snack-Box-Tasty-Nutrient-Rich-Variety-42-Count-by-Gift-A-Snack/14479818419",
+      image: "https://cdn.builder.io/api/v1/image/assets%2F84282e2d620247d2b8d8845fda2c790e%2F79d471e5bc56457eb2c3b1c3eb6586ae?format=webp&width=400",
       type: "view-product-details",
+      useHeroTitle: true,
+      showImages: true,
+      showRating: true,
+      showPricing: true,
+      showPiecesCount: true,
+      piecesCount: 42,
+      piecesCountTitle: "Pieces Count:",
+      piecesCountSubtitle: "Perfect variety for extended enjoyment",
+      showMoreDetails: true,
+      moreDetailsTitle: "More Details",
+      moreDetails: [
+        "Ultimate snack experience in a beautifully designed high-end packaging box",
+        "Packed with a variety of breakfast bars and savory snacks for daily energy",
+        "Individually packaged snacks for convenient grab-and-go options",
+        "Ideal for adults, teens, and college students alike",
+        "Arrives with a heartwarming greeting card for a personal touch"
+      ],
+      primaryButtonText: "Buy Now on Walmart",
+      primaryButtonLink: "https://www.walmart.com/ip/Healthy-Snack-Box-Tasty-Nutrient-Rich-Variety-42-Count-by-Gift-A-Snack/14479818419",
+      secondaryButtonText: "Continue Browsing",
+      subscribeText: "✓ Subscribe & Save available",
+      walmartText: "✓ Walmart+ offer eligible"
     },
     {
       id: "exit-popup",

--- a/client/lib/admin-storage.ts
+++ b/client/lib/admin-storage.ts
@@ -98,6 +98,23 @@ export interface PopupData {
   buttonLink: string;
   image?: string;
   type: "view-product-details" | "exit-intent";
+  // Additional fields for view-product-details popup
+  useHeroTitle?: boolean; // If true, use adminData.hero.title instead of title
+  showImages?: boolean;
+  showRating?: boolean;
+  showPricing?: boolean;
+  showPiecesCount?: boolean;
+  piecesCount?: number;
+  piecesCountTitle?: string;
+  piecesCountSubtitle?: string;
+  showMoreDetails?: boolean;
+  moreDetailsTitle?: string;
+  moreDetails?: string[];
+  primaryButtonText?: string;
+  primaryButtonLink?: string;
+  secondaryButtonText?: string;
+  subscribeText?: string;
+  walmartText?: string;
 }
 
 export interface AdminData {

--- a/client/lib/supabase-admin.ts
+++ b/client/lib/supabase-admin.ts
@@ -22,7 +22,7 @@ export async function checkSupabaseConnection(): Promise<boolean> {
   }
 }
 
-// Upload image to Supabase Storage
+// Upload image to Supabase Storage with improved error handling
 export async function uploadImage(
   file: File,
   path: string,
@@ -37,39 +37,66 @@ export async function uploadImage(
       file.type,
     );
 
-    const fileExt = file.name.split(".").pop();
-    const fileName = `${path}.${fileExt}`;
+    // Validate file type
+    if (!file.type.startsWith("image/")) {
+      throw new Error("File must be an image");
+    }
 
+    // Validate file size (max 5MB)
+    if (file.size > 5 * 1024 * 1024) {
+      throw new Error("File size must be less than 5MB");
+    }
+
+    const fileExt = file.name.split(".").pop()?.toLowerCase();
+    if (!fileExt || !["jpg", "jpeg", "png", "gif", "webp"].includes(fileExt)) {
+      throw new Error("Unsupported file format. Use JPG, PNG, GIF, or WebP");
+    }
+
+    const fileName = `${path}.${fileExt}`;
     console.log("Generated filename:", fileName);
 
+    // Try to upload with upsert to replace existing files
     const { data, error } = await supabase.storage
       .from("images")
       .upload(fileName, file, {
-        cacheControl: "3600",
-        upsert: false,
+        cacheControl: "public, max-age=3600", // 1 hour cache
+        upsert: true, // Replace existing files
       });
 
     if (error) {
       console.error("Supabase upload error:", error);
       console.error("Error details:", {
         message: error.message,
+        statusCode: error.statusCode,
         error: error,
       });
-      return null;
+
+      // Provide specific error messages
+      if (error.message.includes("The resource already exists")) {
+        // Try with a different filename
+        const uniqueFileName = `${path}_${Date.now()}.${fileExt}`;
+        return uploadImage(file, uniqueFileName.replace(`.${fileExt}`, ""));
+      }
+
+      throw new Error(`Upload failed: ${error.message}`);
     }
 
     console.log("Upload successful, data:", data);
 
-    // Get public URL
+    // Get public URL with cache busting
     const { data: urlData } = supabase.storage
       .from("images")
       .getPublicUrl(data.path);
+
+    if (!urlData.publicUrl) {
+      throw new Error("Failed to generate public URL");
+    }
 
     console.log("Generated public URL:", urlData.publicUrl);
     return urlData.publicUrl;
   } catch (error) {
     console.error("Upload failed with exception:", error);
-    return null;
+    throw error; // Re-throw to allow proper error handling
   }
 }
 


### PR DESCRIPTION
## Purpose

Update the View Product Details popup to be 100% identical to the frontend popup, ensuring all texts, prices, images, and fields match exactly in the same order as displayed in the frontend interface.

## Code changes

- **Renamed popup state and handlers**: Changed `showButtonPopup` to `showViewDetailsPopup` and `handleSpecialOfferClick` to `handleViewDetailsClick` for better semantic clarity
- **Updated button click handlers**: Replaced all `handleCardClick` calls with `handleViewDetailsClick` across multiple CTA buttons throughout the component
- **Removed special offer button**: Eliminated the special offer button from the hero section to match frontend design
- **Enhanced popup structure**: Completely rebuilt the popup with detailed product information including:
  - Hero title integration with `useHeroTitle` flag
  - Product images, rating, and pricing sections
  - Pieces count display with customizable title/subtitle
  - More details section with bullet points
  - Primary and secondary action buttons
- **Updated popup configuration**: Modified admin data structure to support new `view-product-details` popup type with extensive customization options including toggleable sections, detailed product information, and multiple button configurations
- **Improved admin interface**: Added comprehensive form sections for configuring all popup elements with proper validation and user guidance

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/acae1b9f078c438f8210b0ff6629ca47/pixel-forge)

👀 [Preview Link](https://acae1b9f078c438f8210b0ff6629ca47-pixel-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>acae1b9f078c438f8210b0ff6629ca47</projectId>-->
<!--<branchName>pixel-forge</branchName>-->